### PR TITLE
typo-Update crypto.rs

### DIFF
--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -51,7 +51,7 @@ pub struct BLSTError(String);
 impl From<BLST_ERROR> for BLSTError {
     fn from(err: BLST_ERROR) -> Self {
         let inner = match err {
-            BLST_ERROR::BLST_SUCCESS => unreachable!("do not create a BLSTError from a sucess"),
+            BLST_ERROR::BLST_SUCCESS => unreachable!("do not create a BLSTError from a success"),
             BLST_ERROR::BLST_BAD_ENCODING => "bad encoding",
             BLST_ERROR::BLST_POINT_NOT_ON_CURVE => "point not on curve",
             BLST_ERROR::BLST_POINT_NOT_IN_GROUP => "point not in group",


### PR DESCRIPTION
# Fix: Corrected typo in source file

## Changes
- `src/crypto.rs:54`: "sucess" corrected to "success".

## Purpose
- Enhanced code accuracy and ensured professionalism by fixing the typo.
